### PR TITLE
Hotfix/fix initial load event

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,14 +7,27 @@
 
 </head>
 <body>
-
+<button class="button--test-fn-1">Show #test-fn-1</button>
 <script type="text/x-whtevr" class="deletewhendone">
   <p id="test3" class="deletewhendone">load immediately</p>
 </script>
 
 <div style="height: 2000px" class="deletewhendone"></div>
-<script type="text/x-whtevr" class="deletewhendone">
+<p>
+
+</p>
+<noscript class="js-whtevr-evt deletewhendone">
+  <img src="http://40.media.tumblr.com/15e7597409b840cc20bd4de23f23e19a/tumblr_n4e0j6iBHs1sdyj9lo1_1280.jpg" alt="" />
+  <img src="http://36.media.tumblr.com/b9e26d4fee1a5572ae92f4cf56e1fdbe/tumblr_n4e0mi1mrk1sdyj9lo1_1280.jpg" alt="" />
+  <img src="http://41.media.tumblr.com/ffe43edae52dc2a346a16ac829a2e9ed/tumblr_n4e0pe0wTu1sdyj9lo1_1280.jpg" alt="" />
+  <p id="test-fn-1" class="deletewhendone">This will show on click</p>
+</noscript>
+<div style="height: 2000px" class="deletewhendone"></div>
+<script type="text/x-whtevr" class="deletewhendone js-test">
   <p id="test" class="deletewhendone">this is a test</p>
+  <img src="http://40.media.tumblr.com/15e7597409b840cc20bd4de23f23e19a/tumblr_n4e0j6iBHs1sdyj9lo1_1280.jpg" alt="" />
+  <img src="http://36.media.tumblr.com/b9e26d4fee1a5572ae92f4cf56e1fdbe/tumblr_n4e0mi1mrk1sdyj9lo1_1280.jpg" alt="" />
+  <img src="http://41.media.tumblr.com/ffe43edae52dc2a346a16ac829a2e9ed/tumblr_n4e0pe0wTu1sdyj9lo1_1280.jpg" alt="" />
 </script>
 
 <div style="height: 5000px" class="deletewhendone"></div>
@@ -27,13 +40,11 @@
   <p id="test4" class="deletewhendone">noscript test</p>
 </noscript>
 
-<div class="button">Click for test 1</div>
-<script type="text/x-whtevr-fn" class="deletewhendone" data-evt="click" data-selector=".button">
+<script type="text/x-whtevr" class="deletewhendone">
   <p id="test" class="deletewhendone">this is a test 1</p>
 </script>
 
-<div class="button--big">Click for test 2</div>
-<script type="text/x-whtevr-fn" class="deletewhendone" data-evt="click" data-selector=".button--big">
+<script type="text/x-whtevr" class="deletewhendone">
   <p id="test2" class="deletewhendone">this is a test 2</p>
 </script>
 
@@ -41,6 +52,29 @@
 <script src="node_modules/jquery/dist/jquery.js"></script>
 <script src="node_modules/when-scroll/dist/when-scroll.min.js"></script>
 <script src="index.js"></script>
+<script>
+  $('.button--test-fn-1').on('click', function () {
 
+    $('.js-whtevr-evt').whtevrLoad();
+
+  });
+
+  $(document).on('whtevr-loaded', '.js-test', function () {
+    console.log('test');
+  });
+
+  $(document).on('whtevr-images-loaded', '.js-test', function () {
+    console.log('test images');
+  });
+
+  $(document).on('whtevr-loaded', '.js-whtevr-evt', function () {
+    console.log('test 2');
+  });
+
+  $(document).on('whtevr-images-loaded', '.js-whtevr-evt', function () {
+    console.log('test images 2');
+  });
+
+</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,10 @@
 
 </head>
 <body>
+<noscript class="js-whtevr blahh">
+  <p id="blahh-test">This should load immediately</p>
+</noscript>
+<div style="height: 3000px" class="deletewhendone"></div>
 <button class="button--test-fn-1">Show #test-fn-1</button>
 <script type="text/x-whtevr" class="deletewhendone">
   <p id="test3" class="deletewhendone">load immediately</p>
@@ -57,6 +61,10 @@
 
     $('.js-whtevr-evt').whtevrLoad();
 
+  });
+
+  $(document).on('whtevr-loaded', '.blahh', function () {
+    console.log('blah working');
   });
 
   $(document).on('whtevr-loaded', '.js-test', function () {

--- a/index.js
+++ b/index.js
@@ -85,14 +85,9 @@
         }, $this.data('load-after'));
       });
     } else {
-      // This is essential for firing the event to a DOM immediately, as set by
-      // the mysterious undocumented third parameter. Because the DOM wasn't
-      // loaded, we could never attach an event to it, and it would fail.
-      $(document).on('ready', function () {
-        whenScroll(['within 300px of', $newElement[0]], function () {
-          loadNow($this, $newElement);
-        }, true);
-      });
+      whenScroll(['within 300px of', $newElement[0]], function () {
+        loadNow($this, $newElement);
+      }, true);
 
     }
   });

--- a/index.js
+++ b/index.js
@@ -62,8 +62,6 @@
       });
     }
     triggerFinished($scriptTag, $tmpElement);
-
-
     // We add an additional parameter to see whether we should remove the DOM
     // element in the triggerFinished function, as we don't want to remove the
     // element if we have images to load, as the `whtevr-images-loaded` trigger

--- a/index.js
+++ b/index.js
@@ -43,6 +43,8 @@
    * @return {null}
    */
   function loadNow($scriptTag, $tmpElement) {
+    // var $scriptTag = this.$scriptTag;
+    // var $tmpElement = this.$tmpElement;
     var isNoscript = ($scriptTag.prop('tagName') === 'NOSCRIPT');
     var $content = isNoscript ? $scriptTag.text() : $scriptTag.html();
     $tmpElement.html($.parseHTML($content));
@@ -54,12 +56,14 @@
         ++imageTicker;
         if (imageCount === imageTicker) {
           $scriptTag
-            .trigger('whtevr-images-loaded', [$tmpElement])
+            .trigger('whtevr-images-loaded', [$tmpElement]);
           removeScriptTag($scriptTag, $tmpElement);
         }
       });
     }
     triggerFinished($scriptTag, $tmpElement);
+
+
     // We add an additional parameter to see whether we should remove the DOM
     // element in the triggerFinished function, as we don't want to remove the
     // element if we have images to load, as the `whtevr-images-loaded` trigger
@@ -83,9 +87,15 @@
         }, $this.data('load-after'));
       });
     } else {
-      whenScroll(['within 300px of', $newElement[0]], function () {
-        loadNow($this, $newElement);
-      }, true);
+      // This is essential for firing the event to a DOM immediately, as set by
+      // the mysterious undocumented third parameter. Because the DOM wasn't
+      // loaded, we could never attach an event to it, and it would fail.
+      $(document).on('ready', function () {
+        whenScroll(['within 300px of', $newElement[0]], function () {
+          loadNow($this, $newElement);
+        }, true);
+      });
+
     }
   });
 

--- a/index.js
+++ b/index.js
@@ -43,8 +43,6 @@
    * @return {null}
    */
   function loadNow($scriptTag, $tmpElement) {
-    // var $scriptTag = this.$scriptTag;
-    // var $tmpElement = this.$tmpElement;
     var isNoscript = ($scriptTag.prop('tagName') === 'NOSCRIPT');
     var $content = isNoscript ? $scriptTag.text() : $scriptTag.html();
     $tmpElement.html($.parseHTML($content));

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/callumacrae/whtevr",
   "dependencies": {
     "jquery": "^1.11.2",
-    "when-scroll": "^0.2.2"
+    "when-scroll": "^0.2.4"
   },
   "devDependencies": {
     "mocha": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/callumacrae/whtevr",
   "dependencies": {
     "jquery": "^1.11.2",
-    "when-scroll": "^0.2.4"
+    "when-scroll": "^0.2.3"
   },
   "devDependencies": {
     "mocha": "^2.2.1",

--- a/test/test.html
+++ b/test/test.html
@@ -32,9 +32,13 @@
 <script type="text/x-whtevr-experiment" class="deletewhendone">
 	<p id="test-fn-1" class="deletewhendone">This will show on click</p>
 </script>
+<div style="height: 3000px" class="deletewhendone"></div>
+<noscript class="js-whtevr js-image deletewhendone">
+	<img src="http://i.imgur.com/OxHKeTw.gif" alt="" class="deletewhendone unbroken-image" style="display: none">
+</noscript>
 
-<noscript class="js-whtevr" class="deletewhendone">
-	<img src="https://images.contentful.com/apgig5q1psgn/6UE4dNSawoc4i8YkaM8MyA/14e1d46aca8c01c703328ec5d1d265c4/shipping-60x60.png" alt="" class="deletewhendone">
+<noscript class="js-whtevr js-image js-broken-image deletewhendone">
+	<img src="https://broken.image/test.gif" alt="" class="deletewhendone broken-image" style="display: none">
 </noscript>
 
 <script src="../node_modules/jquery/dist/jquery.js"></script>

--- a/test/test.html
+++ b/test/test.html
@@ -10,7 +10,7 @@
 
 <div id="mocha"></div>
 
-<script type="text/x-whtevr" class="deletewhendone">
+<script type="text/x-whtevr" class="deletewhendone js-load-immediately">
 	<p id="test3" class="deletewhendone">load immediately</p>
 </script>
 
@@ -41,6 +41,7 @@
 	<img src="https://broken.image/test.gif" alt="" class="deletewhendone broken-image" style="display: none">
 </noscript>
 
+
 <script src="../node_modules/jquery/dist/jquery.js"></script>
 <script src="../node_modules/when-scroll/dist/when-scroll.min.js"></script>
 <script src="../index.js"></script>
@@ -57,6 +58,9 @@
 <script>
 	if (window.mochaPhantomJS) { mochaPhantomJS.run(); }
 	else { mocha.run(); }
+</script>
+
+<script>
 </script>
 
 </body>

--- a/test/whtevr.spec.js
+++ b/test/whtevr.spec.js
@@ -2,6 +2,11 @@
 'use strict';
 
 describe('whtevr', function () {
+  var immediateLoadEvent = false;
+  $('.js-load-immediately').on('whtevr-loaded', function () {
+    immediateLoadEvent = true;
+  });
+
   after(function () {
     $(window).scrollTop(0);
     $('.deletewhendone').remove();
@@ -10,6 +15,10 @@ describe('whtevr', function () {
   describe('non-lazy loading', function () {
     it('should load immediately if on screen', function () {
       $('#test3').length.should.equal(1);
+    });
+
+    it('should fire an event immediately if on screen', function () {
+      immediateLoadEvent.should.equal(true);
     });
   });
 

--- a/test/whtevr.spec.js
+++ b/test/whtevr.spec.js
@@ -14,11 +14,16 @@ describe('whtevr', function () {
 
   describe('non-lazy loading', function () {
     it('should load immediately if on screen', function () {
-      $('#test3').length.should.equal(1);
+      $(document).on('ready', function () {
+        $('#test3').length.should.equal(1);
+      });
+
     });
 
     it('should fire an event immediately if on screen', function () {
-      immediateLoadEvent.should.equal(true);
+      $(document).on('ready', function () {
+        immediateLoadEvent.should.equal(true);
+      });
     });
   });
 

--- a/test/whtevr.spec.js
+++ b/test/whtevr.spec.js
@@ -72,11 +72,24 @@ describe('whtevr', function () {
   describe('noscript', function () {
     var eventFired = false;
     var $element;
+    var imageHasLoaded = false;
+    var brokenImageHasLoaded = false;
 
     before(function () {
       $('.js-whtevr').on('whtevr-loaded', function (e, $el) {
         eventFired = true;
         $element = $el;
+      });
+
+      $('.js-image').whtevrLoad();
+
+      $('.js-image').on('whtevr-images-loaded', function (e, $el) {
+        imageHasLoaded = true;
+
+      });
+
+      $('.js-broken-image').on('whtevr-images-loaded', function (e, $el) {
+        brokenImageHasLoaded = true;
       });
     });
 
@@ -95,6 +108,23 @@ describe('whtevr', function () {
           clearInterval(interval);
         }
       }, 10);
+    });
+
+    it('should have loaded an image', function (done) {
+      var interval = setInterval(function () {
+        if (imageHasLoaded === true) {
+          done();
+          clearInterval(interval);
+        }
+      }, 10);
+    });
+
+    it('should not load an unbroken image', function (done) {
+      setTimeout(function () {
+        if (brokenImageHasLoaded === false) {
+          done();
+        }
+      }, 250);
     });
 
     it('should have fired an event', function () {


### PR DESCRIPTION
Fix an issue where, if an element is set to load on scroll, and the element is within the bounds for firing the whenScroll event on page load, the `whtevr-loaded` event would not attach to the noscript/script tag.
