### PR TITLE
Enable the events to fire on manually initialised whtevrLoad

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,10 @@ $('[type="text/x-whtevr"], .js-whtevr').each(function () {
  */
 $.fn.whtevrLoad = function () {
 	return this.each(function () {
-		loadNow($(this));
+    var $this = $(this);
+    // We create this now because script tags don't have a bounding rect
+    const $placeholder = $('<div class="whtevr-helper" />');
+    $placeholder.insertAfter($this);
+		loadNow($this);
 	});
 };


### PR DESCRIPTION
When initializing whtevr through the `.whtevrLoad()` functionality, we no longer support `whtevr-loaded` and `whtevr-images-loaded` events. This PR fixes that by adding the `.whtevr-helper` div to elements that are initialized in this way.
